### PR TITLE
✨ Add end to end testing capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 *.log
 
-lib
-node_modules
+/chorus-interpreter
+/features/*.actual.*
+/lib
+/node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,9 @@
+/chorus-interpreter
 /example
 /flow-typed
 /git-hooks
 .*
 *.log
 CONTRIBUTING.md
+e2e
 webpack.config.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: java
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 language: java
+addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 jdk: oraclejdk8
-before_install: nvm install 5 && npm install && npm install -g chromedriver
+before_install:
+  - nvm install 5
+  - npm install -g chromedriver
+  - npm install
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 script: npm test
 branches:
   only: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk: oraclejdk8
-before_install: nvm install 5 && npm install
+before_install: nvm install 5 && npm install && npm install -g chromedriver
 script: npm test
 branches:
   only: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-language: node_js
-node_js: '5'
+language: java
+jdk: oraclejdk8
+before_install: nvm install 5
 script: npm test
 branches:
   only: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: java
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk: oraclejdk8
-before_install: nvm install 5
+before_install: nvm install 5 && npm install
 script: npm test
 branches:
   only: master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Build Status](https://travis-ci.org/Chorus-bdd/Chorus-JS.svg?branch=master)](https://travis-ci.org/Chorus-bdd/Chorus-JS)
-
-# chorus-js
+# chorus-js [![Build Status](https://travis-ci.org/Chorus-bdd/chorus-js.svg?branch=master)](https://travis-ci.org/Chorus-bdd/chorus-js)
 A Chorus Javascript Client.
 
 ## Contributing

--- a/e2e
+++ b/e2e
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+WEBPACK_DEV_SERVER_PORT=9000
+CHORUS_INTERPRETER_DIR="./chorus-interpreter"
+FEATURES_DIR="./features"
+
+
+function info {
+	local yellow=`tput setaf 3`
+	local reset=`tput sgr0`
+	echo "${yellow}‣ $1${reset}"
+}
+
+function success {
+	local green=`tput setaf 2`
+	local reset=`tput sgr0`
+	echo "${green}✓ $1${reset}"
+}
+
+function error {
+	local red=`tput setaf 1`
+	local reset=`tput sgr0`
+	echo "${red}✗ $1${reset}"
+}
+
+function show_error_and_exit {
+	error "$1"
+	exit $2
+}
+
+function exit_if_non_zero {
+	if [ $1 -ne 0 ]; then
+		show_error_and_exit "$2" $1
+	fi
+}
+
+function kill_webpack_dev_server {
+	PID=$(lsof -ti :$WEBPACK_DEV_SERVER_PORT)
+	if [ ! -z "$PID" ]; then
+		kill -9 $PID
+	fi
+}
+
+
+if [ ! -d "$CHORUS_INTERPRETER_DIR" ]; then
+	info "Installing latest version of the Chorus interpreter..."
+
+	# get HTML page content
+	HTML=$(curl -L -s http://github.com/nickebbutt/Chorus/releases/latest)
+	exit_if_non_zero $? "Could not find Chorus interpreter latest release HTML page!"
+
+	# find the wanted <a> tag
+	TAR_A_TAG=$(echo "$HTML" | grep -s -E 'href="(.*chorus.*\.tar)')
+	exit_if_non_zero $? "Could not find Chorus interpreter release link tag!"
+
+	# extract href value
+	TAR_RELATIVE_LINK=$(awk -F\" '{print $2}' <<< $TAR_A_TAG)
+	exit_if_non_zero $? "Could not extract Chorus interpreter TAR link!"
+
+	# build absolute url for tar file
+	TAR_URL="http://github.com$TAR_RELATIVE_LINK"
+
+	# download and untar
+	rm -rf "$CHORUS_INTERPRETER_DIR"
+	mkdir "$CHORUS_INTERPRETER_DIR"
+	curl -L $TAR_URL | tar -xz - -C "$CHORUS_INTERPRETER_DIR" --strip-components=1
+	exit_if_non_zero $? "Could not download latest version of the Chorus interpreter!"
+else
+	info "Using already installed version of the Chorus interpreter..."
+fi
+
+info "Starting JS client..."
+npm start&
+
+# Kill webpack-dev-server (was running because of `npm start`)
+trap kill_webpack_dev_server SIGINT SIGTERM EXIT
+
+info "Executing chorus tests..."
+for feature in $FEATURES_DIR/*.feature
+do
+	info "Executing feature: $feature..."
+	$CHORUS_INTERPRETER_DIR/chorus -f $feature > $feature.actual.txt
+
+	info "Diffing output..."
+	git diff --no-index --color-words -w $feature.expected.txt $feature.actual.txt
+	DIFF_EXIT_CODE=$?
+
+	if [ $DIFF_EXIT_CODE -eq 0 ]; then
+		success "Chorus interpreter output has not changed. ($feature)"
+	fi
+
+	rm $feature.actual.txt
+
+	exit_if_non_zero $DIFF_EXIT_CODE "Actual Chorus interpreter output was different from expected! ($feature)"
+done

--- a/e2e
+++ b/e2e
@@ -69,6 +69,14 @@ else
 	info "Using already installed version of the Chorus interpreter..."
 fi
 
+CHROME_DRIVER_PATH=$(which chromedriver)
+exit_if_non_zero $? "Could not find chromedriver executable"
+echo "Using chromedriver at ${CHROME_DRIVER_PATH}"
+
+CHROME_PATH=$(which google-chrome)
+exit_if_non_zero $? "Could not find google-chrome executable"
+echo "Using google-chrome at ${CHROME_PATH}"
+
 info "Starting JS client..."
 npm start&
 

--- a/e2e
+++ b/e2e
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-WEBPACK_DEV_SERVER_PORT=9000
 CHORUS_INTERPRETER_DIR="./chorus-interpreter"
 FEATURES_DIR="./features"
 
@@ -35,10 +34,18 @@ exit_if_non_zero () {
 }
 
 kill_webpack_dev_server () {
-	PID=$(lsof -ti :$WEBPACK_DEV_SERVER_PORT)
-	if [ ! -z "$PID" ]; then
-		kill -9 $PID
+	if [ ! -z "$WEBPACK_DEV_SERVER_PID" ]; then
+		echo "Killing webpack-dev-server using pid $WEBPACK_DEV_SERVER_PID"
+		kill -SIGINT $WEBPACK_DEV_SERVER_PID
+		sleep 1
+
+		if [ $? -ne 0 ] ; then
+			echo "Failed to kill webpack-dev-server"
+		else
+			echo "Killed webpack-dev-server"
+		fi
 	fi
+	return 0
 }
 
 
@@ -73,12 +80,16 @@ CHROME_DRIVER_PATH=$(which chromedriver)
 exit_if_non_zero $? "Could not find chromedriver executable"
 echo "Using chromedriver at ${CHROME_DRIVER_PATH}"
 
-CHROME_PATH=$(which google-chrome)
-exit_if_non_zero $? "Could not find google-chrome executable"
-echo "Using google-chrome at ${CHROME_PATH}"
+if [ "$TRAVIS" ]; then
+	CHROME_PATH=$(which google-chrome)
+	exit_if_non_zero $? "Could not find google-chrome executable"
+	echo "Using google-chrome at ${CHROME_PATH}"
+fi
 
 info "Starting JS client..."
-npm start&
+npm start &
+WEBPACK_DEV_SERVER_PID=$!
+echo "webpack-dev-server pid is $WEBPACK_DEV_SERVER_PID"
 
 # Kill webpack-dev-server (was running because of `npm start`)
 trap kill_webpack_dev_server SIGINT SIGTERM EXIT

--- a/e2e
+++ b/e2e
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 WEBPACK_DEV_SERVER_PORT=9000
 CHORUS_INTERPRETER_DIR="./chorus-interpreter"

--- a/e2e
+++ b/e2e
@@ -2,6 +2,7 @@
 
 CHORUS_INTERPRETER_DIR="./chorus-interpreter"
 FEATURES_DIR="./features"
+WEBPACK_DEV_SERVER_PORT=9000
 
 
 info () {
@@ -35,7 +36,7 @@ exit_if_non_zero () {
 
 kill_webpack_dev_server () {
 	if [ ! -z "$WEBPACK_DEV_SERVER_PID" ]; then
-		echo "Killing webpack-dev-server using pid $WEBPACK_DEV_SERVER_PID"
+		echo "Killing npm webpack-dev-server parent using pid $WEBPACK_DEV_SERVER_PID"
 		kill -SIGINT $WEBPACK_DEV_SERVER_PID
 		sleep 1
 
@@ -44,6 +45,12 @@ kill_webpack_dev_server () {
 		else
 			echo "Killed webpack-dev-server"
 		fi
+	fi
+
+	PID=$(lsof -ti :$WEBPACK_DEV_SERVER_PORT)
+	if [ ! -z "$PID" ]; then
+	    echo "Killing npm webpack server using pid $PID"
+		kill -SIGINT $PID
 	fi
 	return 0
 }

--- a/e2e
+++ b/e2e
@@ -63,8 +63,9 @@ if [ ! -d "$CHORUS_INTERPRETER_DIR" ]; then
 	# download and untar
 	rm -rf "$CHORUS_INTERPRETER_DIR"
 	mkdir "$CHORUS_INTERPRETER_DIR"
-	curl -L $TAR_URL | tar -x - -C "$CHORUS_INTERPRETER_DIR" --strip-components=1
+	curl -L $TAR_URL | tar -x
 	exit_if_non_zero $? "Could not download latest version of the Chorus interpreter!"
+	ls .
 else
 	info "Using already installed version of the Chorus interpreter..."
 fi

--- a/e2e
+++ b/e2e
@@ -5,36 +5,36 @@ CHORUS_INTERPRETER_DIR="./chorus-interpreter"
 FEATURES_DIR="./features"
 
 
-function info {
+info () {
 	yellow=`tput setaf 3`
 	reset=`tput sgr0`
 	echo "${yellow}‣ $1${reset}"
 }
 
-function success {
+success () {
 	green=`tput setaf 2`
 	reset=`tput sgr0`
 	echo "${green}✓ $1${reset}"
 }
 
-function error {
+error () {
 	red=`tput setaf 1`
 	reset=`tput sgr0`
 	echo "${red}✗ $1${reset}"
 }
 
-function show_error_and_exit {
+show_error_and_exit () {
 	error "$1"
 	exit $2
 }
 
-function exit_if_non_zero {
+exit_if_non_zero () {
 	if [ $1 -ne 0 ]; then
 		show_error_and_exit "$2" $1
 	fi
 }
 
-function kill_webpack_dev_server {
+kill_webpack_dev_server () {
 	PID=$(lsof -ti :$WEBPACK_DEV_SERVER_PORT)
 	if [ ! -z "$PID" ]; then
 		kill -9 $PID

--- a/e2e
+++ b/e2e
@@ -6,20 +6,20 @@ FEATURES_DIR="./features"
 
 
 function info {
-	local yellow=`tput setaf 3`
-	local reset=`tput sgr0`
+	yellow=`tput setaf 3`
+	reset=`tput sgr0`
 	echo "${yellow}‣ $1${reset}"
 }
 
 function success {
-	local green=`tput setaf 2`
-	local reset=`tput sgr0`
+	green=`tput setaf 2`
+	reset=`tput sgr0`
 	echo "${green}✓ $1${reset}"
 }
 
 function error {
-	local red=`tput setaf 1`
-	local reset=`tput sgr0`
+	red=`tput setaf 1`
+	reset=`tput sgr0`
 	echo "${red}✗ $1${reset}"
 }
 

--- a/e2e
+++ b/e2e
@@ -63,9 +63,8 @@ if [ ! -d "$CHORUS_INTERPRETER_DIR" ]; then
 	# download and untar
 	rm -rf "$CHORUS_INTERPRETER_DIR"
 	mkdir "$CHORUS_INTERPRETER_DIR"
-	curl -L $TAR_URL | tar -x
+	curl -L $TAR_URL | tar -x -C "$CHORUS_INTERPRETER_DIR" --strip-components=1
 	exit_if_non_zero $? "Could not download latest version of the Chorus interpreter!"
-	ls .
 else
 	info "Using already installed version of the Chorus interpreter..."
 fi

--- a/e2e
+++ b/e2e
@@ -63,7 +63,7 @@ if [ ! -d "$CHORUS_INTERPRETER_DIR" ]; then
 	# download and untar
 	rm -rf "$CHORUS_INTERPRETER_DIR"
 	mkdir "$CHORUS_INTERPRETER_DIR"
-	curl -L $TAR_URL | tar -xz - -C "$CHORUS_INTERPRETER_DIR" --strip-components=1
+	curl -L $TAR_URL | tar -x - -C "$CHORUS_INTERPRETER_DIR" --strip-components=1
 	exit_if_non_zero $? "Could not download latest version of the Chorus interpreter!"
 else
 	info "Using already installed version of the Chorus interpreter..."

--- a/example/createCounter.js
+++ b/example/createCounter.js
@@ -40,6 +40,12 @@ export default function (rootElem: HTMLElement): Counter {
 	}
 
 	clientOpened.then(() => {
+		// simple regression steps
+		client.publishStep('.* call a step with a result', () => 'hello!');
+		client.publishStep('.* call a step without a result', () => {});
+		client.publishStep('.* call a step which fails', () => { expect(true).toBe(false); });
+
+		// app steps
 		client.publishStep('.* click.* decrement button', _handleDecrementButtonClick);
 		client.publishStep('.* click.* increment button', _handleIncrementButtonClick);
 		client.publishStep('.* counter value is (.*)', _checkValue);

--- a/features/basic.feature
+++ b/features/basic.feature
@@ -1,0 +1,20 @@
+Uses: StepServer
+Uses: Selenium
+
+Feature: Basic steps
+
+  #! StepServer start
+  Feature-Start:
+    Given I open Chrome
+
+  Background:
+    Given I navigate to http://localhost:9000
+    And StepServer client SimpleStepPublisher is connected
+
+  Scenario: I can call steps with and without a result
+    Check I can call a step with a result
+    And I can call a step without a result
+
+  Scenario: I can call steps which fail
+    Check I can call a step with a result
+    And I can call a step which fails

--- a/features/basic.feature.expected.txt
+++ b/features/basic.feature.expected.txt
@@ -1,0 +1,19 @@
+Feature: Basic steps
+  Scenario: Feature-Start
+    #! StepServer start                                                                                          PASSED
+    Given I open Chrome                                                                                          PASSED
+  Scenario: I can call steps with and without a result
+    Given I navigate to http://localhost:9000                                                                    PASSED
+    And StepServer client SimpleStepPublisher is connected                                                       PASSED
+    Check I can call a step with a result                                                                        PASSED  hello!
+    And I can call a step without a result                                                                       PASSED
+  Scenario: I can call steps which fail
+    Given I navigate to http://localhost:9000                                                                    PASSED
+    And StepServer client SimpleStepPublisher is connected                                                       PASSED
+    Check I can call a step with a result                                                                        PASSED  hello!
+    And I can call a step which fails                                                                            FAILED  (WebSocketClientStepInvoker:158)-StepFailedException
+
+
+Features  (total:1) (passed:0) (failed:1)
+Scenarios (total:2) (passed:1) (failed:1)
+Steps     (total:10) (passed:9) (failed:1) (undefined:0) (pending:0) (skipped:0)

--- a/features/counter.feature
+++ b/features/counter.feature
@@ -1,0 +1,25 @@
+Uses: StepServer
+Uses: Selenium
+
+Feature: I can use the counter
+
+  #! StepServer start
+  Feature-Start:
+    Given I open Chrome
+
+  Background:
+    Given I navigate to http://localhost:9000
+    And StepServer client SimpleStepPublisher is connected
+
+  Scenario: I can read the counter
+    Then the counter value is 0
+
+  Scenario: I can increment the counter
+    Given the counter value is 0
+    When I click on the increment button
+    Then the counter value is 1
+
+  Scenario: I can decrement the counter
+    Given the counter value is 0
+    When I click on the decrement button
+    Then the counter value is -1

--- a/features/counter.feature.expected.txt
+++ b/features/counter.feature.expected.txt
@@ -1,0 +1,25 @@
+Feature: I can use the counter
+  Scenario: Feature-Start
+    #! StepServer start                                                                                          PASSED
+    Given I open Chrome                                                                                          PASSED
+  Scenario: I can read the counter
+    Given I navigate to http://localhost:9000                                                                    PASSED
+    And StepServer client SimpleStepPublisher is connected                                                       PASSED
+    Then the counter value is 0                                                                                  PASSED  0
+  Scenario: I can increment the counter
+    Given I navigate to http://localhost:9000                                                                    PASSED
+    And StepServer client SimpleStepPublisher is connected                                                       PASSED
+    Given the counter value is 0                                                                                 PASSED  0
+    When I click on the increment button                                                                         PASSED
+    Then the counter value is 1                                                                                  PASSED  1
+  Scenario: I can decrement the counter
+    Given I navigate to http://localhost:9000                                                                    PASSED
+    And StepServer client SimpleStepPublisher is connected                                                       PASSED
+    Given the counter value is 0                                                                                 PASSED  0
+    When I click on the decrement button                                                                         PASSED
+    Then the counter value is -1                                                                                 PASSED  -1
+
+
+Features  (total:1) (passed:1) (failed:0)
+Scenarios (total:3) (passed:3) (failed:0)
+Steps     (total:15) (passed:15) (failed:0) (undefined:0) (pending:0) (skipped:0)

--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
     "start": "webpack-dev-server --progress --colors --inline --hot --quiet",
     "prebuild": "npm run clean",
     "build": "NODE_ENV=production babel ./src --out-dir ./lib",
-    "test": "npm run lint && npm run typecheck && npm run test:unit",
+    "test": "npm run lint && npm run typecheck && npm run test:unit && npm run test:e2e",
     "test:unit": "jest",
+	"test:e2e": "./e2e",
     "preversion": "npm run test",
     "version": "npm run build",
     "postversion": "git push --follow-tags",
     "lint": "eslint . --ignore-pattern lib/ --ignore-pattern flow-typed/",
     "typecheck": "flow",
-    "clean": "rimraf ./lib",
+    "clean": "rimraf ./chorus-interpreter && rimraf ./lib && rimraf ./tests/*.actual.* && rimraf *.log",
     "hook": "cp ./git-hooks/* ./.git/hooks"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Chorus-bdd/Chorus-JS.git"
+    "url": "git+https://github.com/Chorus-bdd/chorus-js.git"
   },
   "author": "Benoît Grélard <benoit.grelard@gmail.com> (http://www.artisologic.com)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Chorus-bdd/Chorus-JS/issues"
+    "url": "https://github.com/Chorus-bdd/chorus-js/issues"
   },
-  "homepage": "https://github.com/Chorus-bdd/Chorus-JS#readme"
+  "homepage": "https://github.com/Chorus-bdd/chorus-js#readme"
 }


### PR DESCRIPTION
Ok, so I've got it to the point you were at yesterday so now the build passes.
A few things before we merge though:

- Although this passes on the CI env, for me the newly added `which google-chrome` check fails on my local machine, I'd like to have something that passes both locally and on CI.
- We're installing chrome driver using the npm wrapper. This is because I didn't know any other way, but we should be able to install it the way you installed chrome maybe?
- Although it ends with a status 0 and a success on Travis, I am not happy with the weird output it produces when killing webpack-dev-server, looks like an error...

Anything else you can see?