### PR TITLE
Upgrade to latest Chorus 3.0.x pre-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /features/*.actual.*
 /lib
 /node_modules
+/chorus-js.iml
+/chorus-js.ipr
+/chorus-js.iws

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ A Chorus Javascript Client.
 
 ## Contributing
 Documentation about contributing [can be found here](/CONTRIBUTING.md).
+

--- a/e2e
+++ b/e2e
@@ -73,6 +73,7 @@ if [ ! -d "$CHORUS_INTERPRETER_DIR" ]; then
 
 	# build absolute url for tar file
 	TAR_URL="http://github.com$TAR_RELATIVE_LINK"
+	echo "Downloading latest Chorus interpreter from ${TAR_URL}"
 
 	# download and untar
 	rm -rf "$CHORUS_INTERPRETER_DIR"

--- a/e2e
+++ b/e2e
@@ -60,7 +60,7 @@ if [ ! -d "$CHORUS_INTERPRETER_DIR" ]; then
 	info "Installing latest version of the Chorus interpreter..."
 
 	# get HTML page content
-	HTML=$(curl -L -s http://github.com/nickebbutt/Chorus/releases/latest)
+	HTML=$(curl -L -s http://github.com/Chorus-bdd/Chorus/releases/latest)
 	exit_if_non_zero $? "Could not find Chorus interpreter latest release HTML page!"
 
 	# find the wanted <a> tag

--- a/e2e
+++ b/e2e
@@ -106,7 +106,7 @@ info "Executing chorus tests..."
 for feature in $FEATURES_DIR/*.feature
 do
 	info "Executing feature: $feature..."
-	$CHORUS_INTERPRETER_DIR/chorus -f $feature > $feature.actual.txt
+	$CHORUS_INTERPRETER_DIR/chorus -f $feature | tee $feature.actual.txt
 
 	info "Diffing output..."
 	git diff --no-index --color-words -w $feature.expected.txt $feature.actual.txt

--- a/example/createCounter.js
+++ b/example/createCounter.js
@@ -33,7 +33,7 @@ export default function (rootElem: ?HTMLElement): Counter {
 		_setValue(_value + 1);
 	}
 
-	function _resetCounter() : void {
+	function _resetCounter(): void {
 		_setValue(0);
 	}
 

--- a/example/createCounter.js
+++ b/example/createCounter.js
@@ -33,6 +33,10 @@ export default function (rootElem: ?HTMLElement): Counter {
 		_setValue(_value + 1);
 	}
 
+	function _resetCounter() : void {
+		_setValue(0);
+	}
+
 	_decrementButton.addEventListener('click', _handleDecrementButtonClick);
 	_incrementButton.addEventListener('click', _handleIncrementButtonClick);
 
@@ -72,6 +76,7 @@ export default function (rootElem: ?HTMLElement): Counter {
 			expect(Number(value)).toEqual(_value);
 			return _value;
 		});
+		client.publishStep('.*reset the counter', _resetCounter);
 
 		// done publishing
 		client.stepsAligned();

--- a/features/basic.feature
+++ b/features/basic.feature
@@ -7,9 +7,7 @@ Feature: Basic steps
   Feature-Start:
     Given I start a web socket server
     And I open Chrome
-
-  Background:
-    Given I navigate to http://localhost:9999
+    And I navigate to http://localhost:9999
     And I wait for the web socket client SimpleStepPublisher
 
   Scenario: I can call steps with and without a result

--- a/features/basic.feature
+++ b/features/basic.feature
@@ -1,16 +1,16 @@
-Uses: StepRegistry
+Uses: Web Sockets
 Uses: Selenium
 Uses: Chorus Context
 
 Feature: Basic steps
 
-  #! StepRegistry start
   Feature-Start:
-    Given I open Chrome
+    Given I start a web socket server
+    And I open Chrome
 
   Background:
     Given I navigate to http://localhost:9999
-    And StepRegistry client SimpleStepPublisher is connected
+    And I wait for the web socket client SimpleStepPublisher
 
   Scenario: I can call steps with and without a result
     Check I can call a step with a result

--- a/features/basic.feature.expected.txt
+++ b/features/basic.feature.expected.txt
@@ -1,35 +1,35 @@
 Feature: Basic steps
   Scenario: Feature-Start
-    #! StepRegistry start                                                                                        PASSED
-    Given I open Chrome                                                                                          PASSED
+    Given I start a web socket server                                                                            PASSED
+    And I open Chrome                                                                                            PASSED
   Scenario: I can call steps with and without a result
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Check I can call a step with a result                                                                        PASSED  hello!
     And I can call a step without a result                                                                       PASSED
   Scenario: I can call steps which fail
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Check I can call a step with a result                                                                        PASSED  hello!
     And I can call a step which fails                                                                            FAILED  Expected true to be false (WebSocketClientStepInvoker:181)-StepFailedException
   Scenario: I can call steps which are async
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Check I can call a step which succeeds asynchronously                                                        PASSED  true
     And I can call a step which times out                                                                        FAILED  Expected false to be true (WebSocketClientStepInvoker:181)-StepFailedException
   Scenario: I can read a variable from the Chorus Context
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Given I create a variable outbound with the value one                                                        PASSED
     Then in chorus-js 'outbound' has the value 'one'                                                             PASSED
   Scenario: I can set a variable in the Chorus Context
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     When I set the 'inbound' variable to 'two' in chorus-js                                                      PASSED
     Then the variable inbound has the value two                                                                  PASSED
   Scenario: I can overwrite a variable in the Chorus Context
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Given I create a variable outbound with the value two                                                        PASSED
     When I set the 'outbound' variable to 'three' in chorus-js                                                   PASSED
     Then the variable outbound has the value three                                                               PASSED

--- a/features/basic.feature.expected.txt
+++ b/features/basic.feature.expected.txt
@@ -1,40 +1,30 @@
-Feature: Basic steps
+Feature: Basic steps                                                                                 
   Scenario: Feature-Start
-    Given I start a web socket server                                                                            PASSED
-    And I open Chrome                                                                                            PASSED
+    Given I start a web socket server                                                                            PASSED  
+    And I open Chrome                                                                                            PASSED  
+    And I navigate to http://localhost:9999                                                                      PASSED  
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED  
   Scenario: I can call steps with and without a result
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Check I can call a step with a result                                                                        PASSED  hello!
-    And I can call a step without a result                                                                       PASSED
+    And I can call a step without a result                                                                       PASSED  
   Scenario: I can call steps which fail
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Check I can call a step with a result                                                                        PASSED  hello!
     And I can call a step which fails                                                                            FAILED  Expected true to be false (WebSocketClientStepInvoker:181)-StepFailedException
   Scenario: I can call steps which are async
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Check I can call a step which succeeds asynchronously                                                        PASSED  true
     And I can call a step which times out                                                                        FAILED  Expected false to be true (WebSocketClientStepInvoker:181)-StepFailedException
   Scenario: I can read a variable from the Chorus Context
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
-    Given I create a variable outbound with the value one                                                        PASSED
-    Then in chorus-js 'outbound' has the value 'one'                                                             PASSED
+    Given I create a variable outbound with the value one                                                        PASSED  
+    Then in chorus-js 'outbound' has the value 'one'                                                             PASSED  
   Scenario: I can set a variable in the Chorus Context
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
-    When I set the 'inbound' variable to 'two' in chorus-js                                                      PASSED
-    Then the variable inbound has the value two                                                                  PASSED
+    When I set the 'inbound' variable to 'two' in chorus-js                                                      PASSED  
+    Then the variable inbound has the value two                                                                  PASSED  
   Scenario: I can overwrite a variable in the Chorus Context
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
-    Given I create a variable outbound with the value two                                                        PASSED
-    When I set the 'outbound' variable to 'three' in chorus-js                                                   PASSED
-    Then the variable outbound has the value three                                                               PASSED
+    Given I create a variable outbound with the value two                                                        PASSED  
+    When I set the 'outbound' variable to 'three' in chorus-js                                                   PASSED  
+    Then the variable outbound has the value three                                                               PASSED  
 
 
 Features  (total:1) (passed:0) (failed:1)
 Scenarios (total:6) (passed:4) (failed:2)
-Steps     (total:27) (passed:25) (failed:2) (undefined:0) (pending:0) (skipped:0)
+Steps     (total:17) (passed:15) (failed:2) (undefined:0) (pending:0) (skipped:0)

--- a/features/counter.feature
+++ b/features/counter.feature
@@ -1,15 +1,15 @@
-Uses: StepRegistry
+Uses: Web Sockets
 Uses: Selenium
 
 Feature: I can use the counter
 
-  #! StepRegistry start
   Feature-Start:
-    Given I open Chrome
+    Given I start a web socket server
+    And I open Chrome
 
   Background:
     Given I navigate to http://localhost:9999
-    And StepRegistry client SimpleStepPublisher is connected
+    And I wait for the web socket client SimpleStepPublisher
 
   Scenario: I can read the counter
     Then the counter value is 0

--- a/features/counter.feature
+++ b/features/counter.feature
@@ -6,20 +6,21 @@ Feature: I can use the counter
   Feature-Start:
     Given I start a web socket server
     And I open Chrome
+    And I navigate to http://localhost:9999
+    And I wait for the web socket client SimpleStepPublisher
 
   Background:
-    Given I navigate to http://localhost:9999
-    And I wait for the web socket client SimpleStepPublisher
+    Given I reset the counter
 
   Scenario: I can read the counter
     Then the counter value is 0
 
   Scenario: I can increment the counter
-    Given the counter value is 0
+    And the counter value is 0
     When I click on the increment button
     Then the counter value is 1
 
   Scenario: I can decrement the counter
-    Given the counter value is 0
+    And the counter value is 0
     When I click on the decrement button
     Then the counter value is -1

--- a/features/counter.feature.expected.txt
+++ b/features/counter.feature.expected.txt
@@ -1,20 +1,20 @@
 Feature: I can use the counter
   Scenario: Feature-Start
-    #! StepRegistry start                                                                                        PASSED
-    Given I open Chrome                                                                                          PASSED
+    Given I start a web socket server                                                                            PASSED
+    And I open Chrome                                                                                            PASSED
   Scenario: I can read the counter
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Then the counter value is 0                                                                                  PASSED  0
   Scenario: I can increment the counter
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Given the counter value is 0                                                                                 PASSED  0
     When I click on the increment button                                                                         PASSED
     Then the counter value is 1                                                                                  PASSED  1
   Scenario: I can decrement the counter
     Given I navigate to http://localhost:9999                                                                    PASSED
-    And StepRegistry client SimpleStepPublisher is connected                                                     PASSED
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
     Given the counter value is 0                                                                                 PASSED  0
     When I click on the decrement button                                                                         PASSED
     Then the counter value is -1                                                                                 PASSED  -1

--- a/features/counter.feature.expected.txt
+++ b/features/counter.feature.expected.txt
@@ -1,25 +1,24 @@
-Feature: I can use the counter
+Feature: I can use the counter                                                                       
   Scenario: Feature-Start
-    Given I start a web socket server                                                                            PASSED
-    And I open Chrome                                                                                            PASSED
+    Given I start a web socket server                                                                            PASSED  
+    And I open Chrome                                                                                            PASSED  
+    And I navigate to http://localhost:9999                                                                      PASSED  
+    And I wait for the web socket client SimpleStepPublisher                                                     PASSED  
   Scenario: I can read the counter
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
+    Given I reset the counter                                                                                    PASSED  
     Then the counter value is 0                                                                                  PASSED  0
   Scenario: I can increment the counter
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
-    Given the counter value is 0                                                                                 PASSED  0
-    When I click on the increment button                                                                         PASSED
+    Given I reset the counter                                                                                    PASSED  
+    And the counter value is 0                                                                                   PASSED  0
+    When I click on the increment button                                                                         PASSED  
     Then the counter value is 1                                                                                  PASSED  1
   Scenario: I can decrement the counter
-    Given I navigate to http://localhost:9999                                                                    PASSED
-    And I wait for the web socket client SimpleStepPublisher                                                     PASSED
-    Given the counter value is 0                                                                                 PASSED  0
-    When I click on the decrement button                                                                         PASSED
+    Given I reset the counter                                                                                    PASSED  
+    And the counter value is 0                                                                                   PASSED  0
+    When I click on the decrement button                                                                         PASSED  
     Then the counter value is -1                                                                                 PASSED  -1
 
 
 Features  (total:1) (passed:1) (failed:0)
 Scenarios (total:3) (passed:3) (failed:0)
-Steps     (total:15) (passed:15) (failed:0) (undefined:0) (pending:0) (skipped:0)
+Steps     (total:14) (passed:14) (failed:0) (undefined:0) (pending:0) (skipped:0)


### PR DESCRIPTION
Hi guys - please feel no urgency on this PR, it's Christmas!  I hope you're having a nice holiday and I wish you all the best for 2018. 

I'm keeping you in the loop for chorus-js PRs mainly to keep you informed of progress. If you're not able to find time to review them, that's cool and I'll do it the merge myself in a bit - but if you are able to have a quick scan then it's great to have your input

These changes bring chorus-js up to date with the latest version of Chorus interpreter pre release for 3.0.x 

Changes:

1. The e2e tests now run by downloading the latest version of Chorus from the Chorus-BDD org, rather than nickebbutt fork
2. The latest Chorus interpreter version has now got colour highlighting, when run from the console, and a summary of any failed features at the end 
3. I created a 'Web Sockets' handler to replace the 'StepRegistry' handler (still available but now deprecated) since I thought this led to simpler/more intuitive tests. 

The feature-start: is now:

```
  Feature-Start:
    Given I start a web socket server
    And I open Chrome
    And I navigate to http://localhost:9999
    And I wait for the web socket client SimpleStepPublisher
```

That seems simpler to me - does it read better to you? The previous was:

```
  #! StepRegistry start
  Feature-Start:
    Given I open Chrome

  Background:
    Given I navigate to http://localhost:9999
    And StepRegistry client SimpleStepPublisher is connected
```

4. In the chorus-js tests, I moved the `navigate` steps which load the page in the browser into the 'Feature-Start' section, so we only load the page once per feature. In the counter test there's a new 'reset the counter' step as Background:. This resets the counter at the start of each scenario, instead of reloading the whole page each time. In general I think it works better in Chorus if all the heavy lifting to set things up e.g. making connections / loading pages etc. runs in the Feature-Start:., but loading a page from a subsequent scenario would still be possible if there's a need to do it that way

6. I also made a change to e2e script so that chorus output is visible in the console during ./e2e test, as well as used to create the .expected. files

### new React/Redux demo app

One more thing, there's now a `chrous-js-react-calculator` app under Chorus-bdd org 
[](https://github.com/Chorus-bdd/chorus-js-react-calculator
)

This shows how Chorus can be used to test a React/Redux app - although the Chorus step implementations are at present just inspecting the DOM rather than having knowledge of react components or Redux state tree. I'm going to have a go at improving that shortly - any advice appreciated!

Nick




